### PR TITLE
Send user to callback if login attempt failed

### DIFF
--- a/src/util/AbstractAPI.js
+++ b/src/util/AbstractAPI.js
@@ -107,12 +107,18 @@ Ext.define('Jarvus.util.AbstractAPI', {
                 if (response.aborted === true) {
                     Ext.callback(options.abort, options.scope, [response]);
                 } else if (response.status == 401 || response.statusText.indexOf('Unauthorized') !== -1) {
-
+                    
                     /*
                     We seem to always get the same session id, so we can't automatically try again once the user logs in
                     var oldSessionID = Ext.util.Cookies.get('s');
                      */
 
+                    // Send user to callback if login attempt has failed
+                    if (options.url == '/login') {
+                        Ext.callback(options.success, options.scope, [response]);
+                        return;
+                    }
+                    
                     Ext.override(Ext.Msg, {
                         hide: function () {
                             var me = this,


### PR DESCRIPTION
When the loadSessionData() function is called to test if the user is logged in, the 'Login Required' notification would appear and the callback ignored. This patch will allow the callback to handle a failed login attempt.